### PR TITLE
Setted default values for Electric and Safety Equipment columns

### DIFF
--- a/db/migrate/20220823232248_add_default_value_to_electric_and_safety_equipment.rb
+++ b/db/migrate/20220823232248_add_default_value_to_electric_and_safety_equipment.rb
@@ -1,0 +1,6 @@
+class AddDefaultValueToElectricAndSafetyEquipment < ActiveRecord::Migration[7.0]
+  def change
+    change_column_default :offers, :electric, false
+    change_column_default :offers, :safety_equipment, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_23_163038) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_23_232248) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -34,8 +34,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_23_163038) do
     t.datetime "updated_at", null: false
     t.string "title"
     t.text "description"
-    t.boolean "electric"
-    t.boolean "safety_equipment"
+    t.boolean "electric", default: false
+    t.boolean "safety_equipment", default: false
     t.string "optional"
     t.index ["user_id"], name: "index_offers_on_user_id"
   end


### PR DESCRIPTION
Had to set up default values (both false) to Electric and Safety Equipment columns, inside Offers Table.